### PR TITLE
Feature/225-73-error-boundary

### DIFF
--- a/packages/client/src/hoc/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/client/src/hoc/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,31 @@
+import { Component, ErrorInfo } from 'react';
+import { H3 } from 'src/design/H3';
+import { Props, State } from './types';
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    error;
+
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return <H3>Что то пошло не так...</H3>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/packages/client/src/hoc/ErrorBoundary/index.ts
+++ b/packages/client/src/hoc/ErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ErrorBoundary';

--- a/packages/client/src/hoc/ErrorBoundary/types.ts
+++ b/packages/client/src/hoc/ErrorBoundary/types.ts
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+export type Props = {
+  children: ReactNode;
+};
+
+export type State = {
+  hasError: boolean;
+};

--- a/packages/client/src/pages/Welcome/Welcome.tsx
+++ b/packages/client/src/pages/Welcome/Welcome.tsx
@@ -1,27 +1,12 @@
 import Switch from 'src/components/Switch';
 import { H1 } from 'src/design/H1';
 import styled from 'styled-components';
-import ErrorBoundary from 'src/hoc/ErrorBoundary/ErrorBoundary';
-import { useState } from 'react';
 
 const Welcome = () => {
   return (
     <Container>
       <Text>Welcome</Text>
       <Switch />
-      <p>2 компонента в одном ErrorBoundary</p>
-      <ErrorBoundary>
-        <Elem />
-        <Elem />
-      </ErrorBoundary>
-      <p>1 компонент в другом ErrorBoundary</p>
-      <ErrorBoundary>
-        <Elem />
-      </ErrorBoundary>
-      <p>еще 1 компонент в еще одном ErrorBoundary</p>
-      <ErrorBoundary>
-       <Elem />
-      </ErrorBoundary>
     </Container>
   );
 };
@@ -41,11 +26,3 @@ const Text = styled(H1)`
   width: max-content;
   color: ${({ theme }) => theme.colors.core.text.primary};
 `;
-
-function Elem() {
-  const [count, setCount] = useState(0);
-
-  if (count === 3) throw new Error('some message');
-
-  return <div style={{fontSize: '30px'}} onClick={() => setCount(count + 1)}>{count}</div>;
-}

--- a/packages/client/src/pages/Welcome/Welcome.tsx
+++ b/packages/client/src/pages/Welcome/Welcome.tsx
@@ -1,12 +1,27 @@
 import Switch from 'src/components/Switch';
 import { H1 } from 'src/design/H1';
 import styled from 'styled-components';
+import ErrorBoundary from 'src/hoc/ErrorBoundary/ErrorBoundary';
+import { useState } from 'react';
 
 const Welcome = () => {
   return (
     <Container>
       <Text>Welcome</Text>
       <Switch />
+      <p>2 компонента в одном ErrorBoundary</p>
+      <ErrorBoundary>
+        <Elem />
+        <Elem />
+      </ErrorBoundary>
+      <p>1 компонент в другом ErrorBoundary</p>
+      <ErrorBoundary>
+        <Elem />
+      </ErrorBoundary>
+      <p>еще 1 компонент в еще одном ErrorBoundary</p>
+      <ErrorBoundary>
+       <Elem />
+      </ErrorBoundary>
     </Container>
   );
 };
@@ -26,3 +41,11 @@ const Text = styled(H1)`
   width: max-content;
   color: ${({ theme }) => theme.colors.core.text.primary};
 `;
+
+function Elem() {
+  const [count, setCount] = useState(0);
+
+  if (count === 3) throw new Error('some message');
+
+  return <div style={{fontSize: '30px'}} onClick={() => setCount(count + 1)}>{count}</div>;
+}


### PR DESCRIPTION
### Добавляем обработку ошибок в компонентах.
Оборачиваем компоненты, которые могут "упасть" в HOC ErrorBoundary

```
<ErrorBoundary>
        <Elem />
</ErrorBoundary>
```
ErrorBoundary создает границы, через которые ошибка не может распространиться на все приложение. Падает только сам компонент не затрагивая остально приложение.

Если завернуть в одну ErrorBoundary 2 компонета, то при падении одного из них оба компонента сломаются
```
<ErrorBoundary>
        <Elem />
        <Elem />
</ErrorBoundary>
```

А вот так все будет работать:

```
<ErrorBoundary>
        <Elem />
</ErrorBoundary>
<ErrorBoundary>
        <Elem />
</ErrorBoundary>
```

### Скриншоты/видяшка 
Компонент падает, когда счетчик на элементе становится равен 3

[Screencast from 10.02.2023 12:35:01.webm](https://user-images.githubusercontent.com/109307026/218046653-94de74ff-c10b-43c1-bb98-03bf38f65ace.webm)

Не уверен насчет типизации, если можно сделать лучше, подскажите)))