### PR TITLE
dynamicly loading whole app, fix some little issues

### DIFF
--- a/packages/client/src/App/App.tsx
+++ b/packages/client/src/App/App.tsx
@@ -1,8 +1,7 @@
 import { Route, Routes } from 'react-router-dom';
 import Layout from 'src/hoc/Layout';
 import PrivateRoute from 'src/hoc/PrivateRoute';
-import { SignIn, SignUp, Welcome, Leaderboard, GameMenu, Settings } from 'src/pages';
-import NotFoundPage from 'pages/404';
+import { SignUp, Welcome, Leaderboard, GameMenu, Settings, SignIn, Page404 } from 'src/pages';
 import { gameRoutes } from 'src/pages/Game';
 import { profileRoutes } from 'src/pages/Profile';
 import { forumRoutes } from 'src/pages/Forum';
@@ -14,31 +13,29 @@ const { login, registration, game, forum, leaderboard, profile, menu, logout, se
 
 function App() {
   return (
-    <>
-      <Routes>
-        <Route element={<Layout />}>
-          {/* Общие */}
-          <Route element={<AuthRoute />}>
-            <Route index element={<Welcome />} />
-            <Route path={login} element={<SignIn />} />
-            <Route path={registration} element={<SignUp />} />
-          </Route>
-
-          {/* Приватные */}
-          <Route element={<PrivateRoute />}>
-            <Route path={menu} element={<GameMenu />} />
-            <Route path={leaderboard} element={<Leaderboard />} />
-            <Route path={game.index}>{gameRoutes}</Route>
-            <Route path={profile.index}>{profileRoutes}</Route>
-            <Route path={forum.index}>{forumRoutes}</Route>
-            <Route path={logout} element={<Logout />} />
-            <Route path={settings} element={<Settings />} />
-          </Route>
-
-          <Route path="*" element={<NotFoundPage />} />
+    <Routes>
+      <Route element={<Layout />}>
+        {/* Общие */}
+        <Route element={<AuthRoute />}>
+          <Route index element={<Welcome />} />
+          <Route path={login} element={<SignIn />} />
+          <Route path={registration} element={<SignUp />} />
         </Route>
-      </Routes>
-    </>
+
+        {/* Приватные */}
+        <Route element={<PrivateRoute />}>
+          <Route path={menu} element={<GameMenu />} />
+          <Route path={leaderboard} element={<Leaderboard />} />
+          <Route path={game.index}>{gameRoutes}</Route>
+          <Route path={profile.index}>{profileRoutes}</Route>
+          <Route path={forum.index}>{forumRoutes}</Route>
+          <Route path={logout} element={<Logout />} />
+          <Route path={settings} element={<Settings />} />
+        </Route>
+
+        <Route path="*" element={<Page404 />} />
+      </Route>
+    </Routes>
   );
 }
 

--- a/packages/client/src/components/Forms/Login/Login.tsx
+++ b/packages/client/src/components/Forms/Login/Login.tsx
@@ -8,9 +8,10 @@ import { Input } from 'components/Input';
 import { Button } from 'components/Button';
 import { H1 } from 'src/design/H1';
 import { formsConsts } from '../consts/formsConsts';
+import { Link } from 'src/components/Link';
 
 const registrationFields = [formsConsts.login, formsConsts.password];
-const { menu } = paths;
+const { menu, registration } = paths;
 
 export const Login = () => {
   const navigate = useNavigate();
@@ -54,6 +55,9 @@ export const Login = () => {
         <Button variant="primary" type="submit">
           LOGIN
         </Button>
+        <Link to={registration} variant="size24">
+          Registration
+        </Link>
       </FormFooter>
     </Form>
   );
@@ -76,8 +80,8 @@ const FormBody = styled('div')`
 `;
 
 const FormFooter = styled('div')`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: grid;
+  justify-items: center;
+  gap: 10px;
   margin-top: 45px;
 `;

--- a/packages/client/src/components/Forms/ProfileForm/ProfileForm.tsx
+++ b/packages/client/src/components/Forms/ProfileForm/ProfileForm.tsx
@@ -44,7 +44,7 @@ const Profile = (props: TypeProfileProps) => {
       </Data>
       <TextLink>
         <Link to={updateData} variant="size24">
-          Edit date
+          Edit data
         </Link>
       </TextLink>
       <TextLink>

--- a/packages/client/src/hoc/WithSuspence/WithSuspence.tsx
+++ b/packages/client/src/hoc/WithSuspence/WithSuspence.tsx
@@ -1,0 +1,14 @@
+import { ComponentType, Suspense } from 'react';
+import Spinner from 'src/components/Spinner';
+
+function WithSuspense<P extends object>(WrappedComponent: ComponentType<P>) {
+  const ComponentWithSuspense = (props: P) => (
+    <Suspense fallback={<Spinner />}>
+      <WrappedComponent {...props} />
+    </Suspense>
+  );
+
+  return ComponentWithSuspense;
+}
+
+export default WithSuspense;

--- a/packages/client/src/hoc/WithSuspence/index.tsx
+++ b/packages/client/src/hoc/WithSuspence/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './WithSuspence';

--- a/packages/client/src/pages/Forum/Forum.tsx
+++ b/packages/client/src/pages/Forum/Forum.tsx
@@ -1,3 +1,5 @@
-export const Forum = () => {
+const Forum = () => {
   return <div>Страница со списком всех тем</div>;
 };
+
+export default Forum;

--- a/packages/client/src/pages/Forum/Routes.tsx
+++ b/packages/client/src/pages/Forum/Routes.tsx
@@ -1,8 +1,10 @@
+import { lazy } from 'react';
 import { Route } from 'react-router-dom';
 import { paths } from 'src/App/constants';
-import { Forum } from './Forum';
+import WithSuspense from 'src/hoc/WithSuspence';
 
 const { edit, id, newForum, index } = paths.forum;
+const Forum = WithSuspense(lazy(() => import('./Forum')));
 
 export const routes = [
   <Route index element={<Forum />} key={index} />,

--- a/packages/client/src/pages/Game/Game.tsx
+++ b/packages/client/src/pages/Game/Game.tsx
@@ -6,7 +6,7 @@ import { Ground } from 'pages/Game/controllers/Ground/Ground';
 import { useDidMount, useWillUnmount } from 'src/hooks/react';
 import { Platforms } from './controllers/Platforms/Platforms';
 
-export const Game = () => {
+const Game = () => {
   const sizes = useMemo<TSizes>(() => ({ width: 500, height: 600 }), []);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const canvasContextRef = useRef<CanvasRenderingContext2D | null>(null);
@@ -110,6 +110,8 @@ export const Game = () => {
     </GameWindow>
   );
 };
+
+export default Game;
 
 const GameWindow = styled.div`
   border: 1px solid black;

--- a/packages/client/src/pages/Game/Routes.tsx
+++ b/packages/client/src/pages/Game/Routes.tsx
@@ -1,8 +1,10 @@
+import { lazy } from 'react';
 import { Route } from 'react-router-dom';
 import { paths } from 'src/App/constants';
-import { Game } from './Game';
+import WithSuspense from 'src/hoc/WithSuspence';
 
 const { lose, win, index } = paths.game;
+const Game = WithSuspense(lazy(() => import('./Game')));
 
 export const routes = [
   <Route index path="/game" element={<Game />} key={index} />,

--- a/packages/client/src/pages/Profile/Routes.tsx
+++ b/packages/client/src/pages/Profile/Routes.tsx
@@ -1,10 +1,12 @@
+import { lazy } from 'react';
 import { Route } from 'react-router-dom';
 import { paths } from 'src/App/constants';
-import ProfilePassword from 'src/components/Forms/ProfilePassword/ProfilePassword';
-import ProfileUpdateData from './pages/ProfileUpdateData';
-import Profile from './Profile';
+import WithSuspense from 'src/hoc/WithSuspence';
 
 const { updateData, updatePassword, index } = paths.profile;
+const Profile = WithSuspense(lazy(() => import('./Profile')));
+const ProfilePassword = WithSuspense(lazy(() => import('./pages/ProfileUpdatePassword')));
+const ProfileUpdateData = WithSuspense(lazy(() => import('./pages/ProfileUpdateData')));
 
 export const routes = [
   <Route index element={<Profile />} key={index} />,

--- a/packages/client/src/pages/SignIn/SignIn.tsx
+++ b/packages/client/src/pages/SignIn/SignIn.tsx
@@ -30,13 +30,10 @@ const LoginComponent = styled.div`
   flex-direction: column;
   align-items: center;
   width: 402px;
-  height: 372px;
-  box-shadow: 0 0 6px ${({ theme }) => theme.colors.core.background.primary};
   border-radius: 20px;
   background-color: ${({ theme }) => theme.colors.core.background.primary};
   padding: 14px 19px 24px 29px;
   @media (max-width: ${mobileM}) {
     width: 354px;
-    height: 372px;
   }
 `;

--- a/packages/client/src/pages/index.ts
+++ b/packages/client/src/pages/index.ts
@@ -1,8 +1,11 @@
-export { default as Page404 } from './404';
-export { default as ErrorPage } from './ErrorPage';
-export { default as SignIn } from './SignIn';
-export { default as SignUp } from './SignUp';
-export { default as Welcome } from './Welcome';
-export { default as Leaderboard } from './Leaderboard';
-export { default as GameMenu } from './Menu';
-export { default as Settings } from './Settings';
+import { lazy } from 'react';
+import WithSuspense from 'src/hoc/WithSuspence';
+
+export const Page404 = WithSuspense(lazy(() => import('./404')));
+export const ErrorPage = WithSuspense(lazy(() => import('./ErrorPage')));
+export const SignIn = WithSuspense(lazy(() => import('./SignIn')));
+export const SignUp = WithSuspense(lazy(() => import('./SignUp')));
+export const Welcome = WithSuspense(lazy(() => import('./Welcome')));
+export const Leaderboard = WithSuspense(lazy(() => import('./Leaderboard')));
+export const GameMenu = WithSuspense(lazy(() => import('./Menu')));
+export const Settings = WithSuspense(lazy(() => import('./Settings')));


### PR DESCRIPTION
Динамически загружаем только тот контент который нужен, а не целое приложение как до этого.
Так как загружаем динамически только определенные странички - мы подтягиваем не все компоненты/остальные части приложения, а только то, что используется на странице.

До:
![before](https://user-images.githubusercontent.com/49876296/219990735-f78ad53f-5524-4b9d-8cc1-ce5b5a6da65d.png)
После:
![after](https://user-images.githubusercontent.com/49876296/219990749-5d30de03-504d-4154-8421-5be304f4b14c.png)

Т.к. приложение у нас небольшое цифры конечно смешные, то отрисовка улучшилась в полтора раза (FirstContentFull Paint): Было ~390мс => стало ~260мс